### PR TITLE
Fixes a crash when the asset pipeline is disabled

### DIFF
--- a/lib/components/engine.rb
+++ b/lib/components/engine.rb
@@ -3,7 +3,7 @@ module Components
     isolate_namespace Components
 
     initializer "components.asset_paths" do |app|
-      app.config.assets.paths << Components.components_path
+      app.config.assets.paths << Components.components_path if app.config.respond_to?(:assets)
     end
 
     initializer "components.view_helpers" do


### PR DESCRIPTION
Fixes #24.

This PR resolves a crash when the asset pipeline is disabled.