### PR TITLE
Add rubocop as a development dependency to simplify setup

### DIFF
--- a/components.gemspec
+++ b/components.gemspec
@@ -18,5 +18,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", ">= 5.1.0"
 
+  s.add_development_dependency "rubocop"
   s.add_development_dependency "sqlite3"
 end


### PR DESCRIPTION
Just added rubocop as a development dependency to ease setup and execution.