### PR TITLE
Support validations for component attributes and elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,21 @@ An alternative here is to pass a data structure to the component as an attribute
 <%= component "navigation", items: items %>
 ```
 
+Similar to components defined elements can have validations too:
+
+```ruby
+class NavigationComponent < Components::Component
+  element :items, multiple: true do
+    attribute :label
+    attribute :url
+    attribute :active, default: false
+    
+    validate :label, presence: true
+    validate :url, presence: true
+  end
+end
+```
+
 Elements can also be nested, although it is recommended to keep nesting to a minimum:
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -201,6 +201,23 @@ class AlertComponent < Components::Component
 end
 ```
 
+### Attribute validation
+
+To ensure your components get initialized properly you can use `ActiveModel::Validations` in your elements or components:
+
+```ruby
+# app/components/alert_component.rb %>
+
+class AlertComponent < Components::Component
+  attribute :label
+  
+  validates :label, presence: true
+end
+
+```
+
+Your validations will be executed during the components initialization and raise an `ActiveModel::ValidationError` if any validation fails.
+
 ### Elements
 
 Attributes and blocks are great for simple components or components backed by a data structure, such as a model. Other components are more generic in nature and can be used in a variety of contexts. Often they consist of multiple parts or elements, that sometimes repeat, and sometimes need their own modifiers.
@@ -422,24 +439,6 @@ end
 <%= component "button", label: "Sign up", url: sign_up_path, context: "primary" %>
 <%= component "button", label: "Sign in", url: sign_in_path %>
 ```
-
-### Validation
-
-To ensure your components get initialized properly you can use ActiveModel::Validations in your elements or components:
-
-```ruby
-# app/components/button_component.rb %>
-
-class ButtonComponent < Components::Component
-  attribute :label
-  attribute :url
-  
-  validates :label, presence: true
-end
-
-```
-
-Your validations will be executed during the components initialization and raise an ActiveModel::ValidationError if any validation fails.
 
 ### Namespaced components
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,6 @@ class AlertComponent < Components::Component
   
   validates :label, presence: true
 end
-
 ```
 
 Your validations will be executed during the components initialization and raise an `ActiveModel::ValidationError` if any validation fails.
@@ -334,7 +333,7 @@ An alternative here is to pass a data structure to the component as an attribute
 <%= component "navigation", items: items %>
 ```
 
-Similar to components defined elements can have validations too:
+Elements can have validations, too:
 
 ```ruby
 class NavigationComponent < Components::Component
@@ -343,8 +342,8 @@ class NavigationComponent < Components::Component
     attribute :url
     attribute :active, default: false
     
-    validate :label, presence: true
-    validate :url, presence: true
+    validates :label, presence: true
+    validates :url, presence: true
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -122,13 +122,13 @@ end
 <%= component "alert", message: "Something went wrong!", context: "danger" %>
 ```
 
-To inject some text or HTML content into our component we can print the components ```block``` attribute in our template, and populate it by passing a block to the component helper:
+To inject some text or HTML content into our component we can print the component variable in our template, and populate it by passing a block to the component helper:
 
 ```erb
 <% # app/components/alert/_alert.html.erb %>
 
 <div class="alert alert--<%= alert.context %>" role="alert">
-  <%= alert.block %>
+  <%= alert %>
 </div>
 ```
 
@@ -136,18 +136,6 @@ To inject some text or HTML content into our component we can print the componen
 <%= component "alert", context: "success" do %>
   <em>Something</em> went right!
 <% end %>
-```
-
-In case you want to render the block and some surrounding HTML only when a block exists you can verify with the ```block?``` method:  
-
-```erb
-<% # app/components/alert/_alert.html.erb %>
-
-<div class="alert alert--<%= alert.context %>" role="alert">
-  <% if alert.block? %>
-    <div class="alert alert-body"><%= alert.block %></div>
-  <% end %>
-</div>
 ```
 
 Another good use case for attributes is when you have a component backed by a model:
@@ -282,15 +270,15 @@ end
 
 <div class="card <%= "card--flush" if card.flush %>">
   <div class="card__header <%= "card__header--centered" if card.header.centered %>">
-    <%= card.header.block %>
+    <%= card.header %>
   </div>
   <% card.sections.each do |section| %>
     <div class="card__section <%= "card__section--#{section.size}" %>">
-      <%= section.block %>
+      <%= section %>
     </div>
   <% end %>
   <div class="card__footer">
-    <%= card.footer.block %>
+    <%= card.footer %>
   </div>
 </div>
 ```
@@ -429,7 +417,7 @@ end
 <%= content_tag :div, class: card.css_classes do %>
   ...
   <%= content_tag :div, class: section.css_classes do %>
-    <%= section.block %>
+    <%= section %>
   <% end %>
   ...
 <% end %>

--- a/README.md
+++ b/README.md
@@ -423,6 +423,28 @@ end
 <%= component "button", label: "Sign in", url: sign_in_path %>
 ```
 
+### Component validation
+
+To ensure your components get initialized correctly you can use Rails validations. You can include the Rails ActiveModel::Validations module into each component separatly or include it into your ApplicationComponent to enable validations on all components.
+
+Afterwards you can define your validations in your components:
+
+```ruby
+# app/components/button_component.rb %>
+
+class ButtonComponent < Components::Component
+  include ActiveModel::Validations
+  
+  attribute :label
+  attribute :url
+  
+  validates :label, presence: true
+end
+
+```
+
+Your validations will be executed during the components initialization and raise an ActiveModel::ValidationError if any validation fails.
+
 ### Namespaced components
 
 Components can be nested under a namespace. This is useful if you want to practice things like [Atomic Design](http://bradfrost.com/blog/post/atomic-web-design/), [BEMIT](https://csswizardry.com/2015/08/bemit-taking-the-bem-naming-convention-a-step-further/) or any other component classification scheme. In order to create a namespaced component, stick it in a folder and wrap the class in a module:

--- a/README.md
+++ b/README.md
@@ -423,18 +423,14 @@ end
 <%= component "button", label: "Sign in", url: sign_in_path %>
 ```
 
-### Component validation
+### Validation
 
-To ensure your components get initialized correctly you can use Rails validations. You can include the Rails ActiveModel::Validations module into each component separatly or include it into your ApplicationComponent to enable validations on all components.
-
-Afterwards you can define your validations in your components:
+To ensure your components get initialized properly you can use ActiveModel::Validations in your elements or components:
 
 ```ruby
 # app/components/button_component.rb %>
 
 class ButtonComponent < Components::Component
-  include ActiveModel::Validations
-  
   attribute :label
   attribute :url
   

--- a/README.md
+++ b/README.md
@@ -122,13 +122,13 @@ end
 <%= component "alert", message: "Something went wrong!", context: "danger" %>
 ```
 
-To inject some HTML content into our component we can print the component variable in our template, and populate it by passing a block to the component helper:
+To inject some text or HTML content into our component we can print the components ```block_content``` attribute in our template, and populate it by passing a block to the component helper:
 
 ```erb
 <% # app/components/alert/_alert.html.erb %>
 
 <div class="alert alert--<%= alert.context %>" role="alert">
-  <%= alert %>
+  <%= alert.block_content %>
 </div>
 ```
 
@@ -136,6 +136,18 @@ To inject some HTML content into our component we can print the component variab
 <%= component "alert", context: "success" do %>
   <em>Something</em> went right!
 <% end %>
+```
+
+In case you want to render the block and some surrounding HTML only when a block exists you can verify with the ```block_content?``` method:  
+
+```erb
+<% # app/components/alert/_alert.html.erb %>
+
+<div class="alert alert--<%= alert.context %>" role="alert">
+  <% if alert.block_content? %>
+    <div class="alert alert-body"><%= alert.block_content %></div>
+  <% end %>
+</div>
 ```
 
 Another good use case for attributes is when you have a component backed by a model:
@@ -270,15 +282,15 @@ end
 
 <div class="card <%= "card--flush" if card.flush %>">
   <div class="card__header <%= "card__header--centered" if card.header.centered %>">
-    <%= card.header %>
+    <%= card.header.block_content %>
   </div>
   <% card.sections.each do |section| %>
     <div class="card__section <%= "card__section--#{section.size}" %>">
-      <%= section %>
+      <%= section.block_content %>
     </div>
   <% end %>
   <div class="card__footer">
-    <%= card.footer %>
+    <%= card.footer.block_content %>
   </div>
 </div>
 ```
@@ -417,7 +429,7 @@ end
 <%= content_tag :div, class: card.css_classes do %>
   ...
   <%= content_tag :div, class: section.css_classes do %>
-    <%= section %>
+    <%= section.block_content %>
   <% end %>
   ...
 <% end %>

--- a/README.md
+++ b/README.md
@@ -122,13 +122,13 @@ end
 <%= component "alert", message: "Something went wrong!", context: "danger" %>
 ```
 
-To inject some text or HTML content into our component we can print the components ```block_content``` attribute in our template, and populate it by passing a block to the component helper:
+To inject some text or HTML content into our component we can print the components ```block``` attribute in our template, and populate it by passing a block to the component helper:
 
 ```erb
 <% # app/components/alert/_alert.html.erb %>
 
 <div class="alert alert--<%= alert.context %>" role="alert">
-  <%= alert.block_content %>
+  <%= alert.block %>
 </div>
 ```
 
@@ -138,14 +138,14 @@ To inject some text or HTML content into our component we can print the componen
 <% end %>
 ```
 
-In case you want to render the block and some surrounding HTML only when a block exists you can verify with the ```block_content?``` method:  
+In case you want to render the block and some surrounding HTML only when a block exists you can verify with the ```block?``` method:  
 
 ```erb
 <% # app/components/alert/_alert.html.erb %>
 
 <div class="alert alert--<%= alert.context %>" role="alert">
-  <% if alert.block_content? %>
-    <div class="alert alert-body"><%= alert.block_content %></div>
+  <% if alert.block? %>
+    <div class="alert alert-body"><%= alert.block %></div>
   <% end %>
 </div>
 ```
@@ -282,15 +282,15 @@ end
 
 <div class="card <%= "card--flush" if card.flush %>">
   <div class="card__header <%= "card__header--centered" if card.header.centered %>">
-    <%= card.header.block_content %>
+    <%= card.header.block %>
   </div>
   <% card.sections.each do |section| %>
     <div class="card__section <%= "card__section--#{section.size}" %>">
-      <%= section.block_content %>
+      <%= section.block %>
     </div>
   <% end %>
   <div class="card__footer">
-    <%= card.footer.block_content %>
+    <%= card.footer.block %>
   </div>
 </div>
 ```
@@ -429,7 +429,7 @@ end
 <%= content_tag :div, class: card.css_classes do %>
   ...
   <%= content_tag :div, class: section.css_classes do %>
-    <%= section.block_content %>
+    <%= section.block %>
   <% end %>
   ...
 <% end %>

--- a/lib/components/component.rb
+++ b/lib/components/component.rb
@@ -1,5 +1,9 @@
 module Components
   class Component < Element
+    def self.model_name
+      ActiveModel::Name.new(Components::Component)
+    end
+
     def self.component_name
       name.chomp("Component").demodulize.underscore
     end

--- a/lib/components/element.rb
+++ b/lib/components/element.rb
@@ -57,23 +57,22 @@ module Components
     # rubocop:enable Metrics/MethodLength
     # rubocop:enable Metrics/PerceivedComplexity
 
-    attr_reader :nested_block
+    attr_reader :content_block
 
     def initialize(view, attributes = nil, &block)
       @view = view
-      @nested_block = block
       initialize_attributes(attributes || {})
       initialize_elements
-      @yield = nested_block? ? @view.capture(self, &nested_block) : nil
+      @content_block = block_given? ? @view.capture(self, &block): nil
       validate!
     end
 
-    def nested_block?
-      nested_block.present?
+    def content_block?
+      @content_block.present?
     end
 
     def to_s
-      @yield
+      @content_block
     end
 
     protected

--- a/lib/components/element.rb
+++ b/lib/components/element.rb
@@ -45,16 +45,25 @@ module Components
         get_instance_variable(plural_name)
       end
     end
+
     # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/CyclomaticComplexity
     # rubocop:enable Metrics/MethodLength
     # rubocop:enable Metrics/PerceivedComplexity
 
+    attr_reader :nested_block
+
     def initialize(view, attributes = nil, &block)
       @view = view
+      @nested_block = block
       initialize_attributes(attributes || {})
       initialize_elements
-      @yield = block ? @view.capture(self, &block) : nil
+      @yield = nested_block? ? @view.capture(self, &nested_block) : nil
+      run_validations
+    end
+
+    def nested_block?
+      nested_block.present?
     end
 
     def to_s
@@ -77,6 +86,14 @@ module Components
           set_instance_variable(name, nil)
         end
       end
+    end
+
+    def run_validations
+      validate! if validate?
+    end
+
+    def validate?
+      self.class.included_modules.include?(ActiveModel::Validations)
     end
 
     private

--- a/lib/components/element.rb
+++ b/lib/components/element.rb
@@ -51,7 +51,6 @@ module Components
         get_instance_variable(plural_name)
       end
     end
-
     # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/CyclomaticComplexity
     # rubocop:enable Metrics/MethodLength
@@ -69,10 +68,6 @@ module Components
 
     def block_content?
       block_content.present?
-    end
-
-    def to_s
-      block_content
     end
 
     protected

--- a/lib/components/element.rb
+++ b/lib/components/element.rb
@@ -2,6 +2,10 @@ module Components
   class Element
     include ActiveModel::Validations
 
+    def self.model_name
+      ActiveModel::Name.new(Components::Element)
+    end
+
     def self.attributes
       @attributes ||= {}
     end

--- a/lib/components/element.rb
+++ b/lib/components/element.rb
@@ -56,18 +56,18 @@ module Components
     # rubocop:enable Metrics/MethodLength
     # rubocop:enable Metrics/PerceivedComplexity
 
-    attr_reader :block_content
+    attr_reader :block
 
     def initialize(view, attributes = nil, &block)
       @view = view
       initialize_attributes(attributes || {})
       initialize_elements
-      @block_content = block_given? ? @view.capture(self, &block) : nil
+      @block = block_given? ? @view.capture(self, &block) : nil
       validate!
     end
 
-    def block_content?
-      block_content.present?
+    def block?
+      block.present?
     end
 
     protected

--- a/lib/components/element.rb
+++ b/lib/components/element.rb
@@ -63,7 +63,7 @@ module Components
       @view = view
       initialize_attributes(attributes || {})
       initialize_elements
-      @content_block = block_given? ? @view.capture(self, &block): nil
+      @content_block = block_given? ? @view.capture(self, &block) : nil
       validate!
     end
 

--- a/lib/components/element.rb
+++ b/lib/components/element.rb
@@ -57,22 +57,22 @@ module Components
     # rubocop:enable Metrics/MethodLength
     # rubocop:enable Metrics/PerceivedComplexity
 
-    attr_reader :content_block
+    attr_reader :block_content
 
     def initialize(view, attributes = nil, &block)
       @view = view
       initialize_attributes(attributes || {})
       initialize_elements
-      @content_block = block_given? ? @view.capture(self, &block) : nil
+      @block_content = block_given? ? @view.capture(self, &block) : nil
       validate!
     end
 
-    def content_block?
-      content_block.present?
+    def block_content?
+      block_content.present?
     end
 
     def to_s
-      content_block
+      block_content
     end
 
     protected

--- a/lib/components/element.rb
+++ b/lib/components/element.rb
@@ -56,18 +56,16 @@ module Components
     # rubocop:enable Metrics/MethodLength
     # rubocop:enable Metrics/PerceivedComplexity
 
-    attr_reader :block
-
     def initialize(view, attributes = nil, &block)
       @view = view
       initialize_attributes(attributes || {})
       initialize_elements
-      @block = block_given? ? @view.capture(self, &block) : nil
+      @yield = block_given? ? @view.capture(self, &block) : nil
       validate!
     end
 
-    def block?
-      block.present?
+    def to_s
+      @yield
     end
 
     protected

--- a/lib/components/element.rb
+++ b/lib/components/element.rb
@@ -68,11 +68,11 @@ module Components
     end
 
     def content_block?
-      @content_block.present?
+      content_block.present?
     end
 
     def to_s
-      @content_block
+      content_block
     end
 
     protected

--- a/lib/components/element.rb
+++ b/lib/components/element.rb
@@ -1,5 +1,7 @@
 module Components
   class Element
+    include ActiveModel::Validations
+
     def self.attributes
       @attributes ||= {}
     end
@@ -59,7 +61,7 @@ module Components
       initialize_attributes(attributes || {})
       initialize_elements
       @yield = nested_block? ? @view.capture(self, &nested_block) : nil
-      run_validations
+      validate!
     end
 
     def nested_block?
@@ -86,14 +88,6 @@ module Components
           set_instance_variable(name, nil)
         end
       end
-    end
-
-    def run_validations
-      validate! if validate?
-    end
-
-    def validate?
-      self.class.included_modules.include?(ActiveModel::Validations)
     end
 
     private

--- a/test/component_test.rb
+++ b/test/component_test.rb
@@ -176,7 +176,7 @@ class ComponentTest < ActiveSupport::TestCase
         c.foo(label: "lalal") { "label" }
       end
     end
-    
+
     assert_equal "Validation failed: Bar can't be blank", e.message
   end
 

--- a/test/component_test.rb
+++ b/test/component_test.rb
@@ -5,14 +5,14 @@ class ComponentTest < ActiveSupport::TestCase
     component_class = Class.new(Components::Component)
     component = component_class.new(view_class.new)
     assert_nil component.to_s
-    assert_equal false, component.content_block?
+    assert_equal false, component.block_content?
   end
 
   test "initialize with block" do
     component_class = Class.new(Components::Component)
     component = component_class.new(view_class.new) { "foo" }
     assert_equal "foo", component.to_s
-    assert_equal true, component.content_block?
+    assert_equal true, component.block_content?
   end
 
   test "initialize attribute with no value" do

--- a/test/component_test.rb
+++ b/test/component_test.rb
@@ -4,15 +4,13 @@ class ComponentTest < ActiveSupport::TestCase
   test "initialize with nothing" do
     component_class = Class.new(Components::Component)
     component = component_class.new(view_class.new)
-    assert_nil component.block
-    assert_equal false, component.block?
+    assert_nil component.to_s
   end
 
   test "initialize with block" do
     component_class = Class.new(Components::Component)
     component = component_class.new(view_class.new) { "foo" }
-    assert_equal "foo", component.block
-    assert_equal true, component.block?
+    assert_equal "foo", component.to_s
   end
 
   test "initialize attribute with no value" do
@@ -28,7 +26,7 @@ class ComponentTest < ActiveSupport::TestCase
       attribute :foo
     end
     component = component_class.new(view_class.new, foo: "foo")
-    assert_equal "foo", component.foo
+    assert_equal "foo", component.foo.to_s
   end
 
   test "initialize attribute with default value" do
@@ -36,7 +34,7 @@ class ComponentTest < ActiveSupport::TestCase
       attribute :foo, default: "foo"
     end
     component = component_class.new(view_class.new)
-    assert_equal "foo", component.foo
+    assert_equal "foo", component.foo.to_s
   end
 
   test "initialize element with block" do
@@ -45,7 +43,7 @@ class ComponentTest < ActiveSupport::TestCase
     end
     component = component_class.new(view_class.new)
     component.foo { "foo" }
-    assert_equal "foo", component.foo.block
+    assert_equal "foo", component.foo.to_s
   end
 
   test "initialize element with attribute with value" do
@@ -56,7 +54,7 @@ class ComponentTest < ActiveSupport::TestCase
     end
     component = component_class.new(view_class.new)
     component.foo bar: "baz"
-    assert_equal "baz", component.foo.bar
+    assert_equal "baz", component.foo.bar.to_s
   end
 
   test "initialize element with block with nested element with block" do
@@ -72,8 +70,8 @@ class ComponentTest < ActiveSupport::TestCase
       end
       "foo"
     end
-    assert_equal "foo", component.foo.block
-    assert_equal "bar", component.foo.bar.block
+    assert_equal "foo", component.foo.to_s
+    assert_equal "bar", component.foo.bar.to_s
   end
 
   test "initialize element with multiple true" do
@@ -84,8 +82,8 @@ class ComponentTest < ActiveSupport::TestCase
     component.foo { "foo" }
     component.foo { "bar" }
     assert_equal 2, component.foos.length
-    assert_equal "foo", component.foos[0].block
-    assert_equal "bar", component.foos[1].block
+    assert_equal "foo", component.foos[0].to_s
+    assert_equal "bar", component.foos[1].to_s
   end
 
   test "initialize element with multiple true when singular and plural name are the same" do
@@ -96,8 +94,8 @@ class ComponentTest < ActiveSupport::TestCase
     component.foos { "foo" }
     component.foos { "bar" }
     assert_equal 2, component.foos.length
-    assert_equal "foo", component.foos[0].block
-    assert_equal "bar", component.foos[1].block
+    assert_equal "foo", component.foos[0].to_s
+    assert_equal "bar", component.foos[1].to_s
   end
 
   test "get element when not set" do

--- a/test/component_test.rb
+++ b/test/component_test.rb
@@ -5,14 +5,14 @@ class ComponentTest < ActiveSupport::TestCase
     component_class = Class.new(Components::Component)
     component = component_class.new(view_class.new)
     assert_nil component.to_s
-    assert_equal false, component.nested_block?
+    assert_equal false, component.content_block?
   end
 
   test "initialize with block" do
     component_class = Class.new(Components::Component)
     component = component_class.new(view_class.new) { "foo" }
     assert_equal "foo", component.to_s
-    assert_equal true, component.nested_block?
+    assert_equal true, component.content_block?
   end
 
   test "initialize attribute with no value" do

--- a/test/component_test.rb
+++ b/test/component_test.rb
@@ -4,15 +4,15 @@ class ComponentTest < ActiveSupport::TestCase
   test "initialize with nothing" do
     component_class = Class.new(Components::Component)
     component = component_class.new(view_class.new)
-    assert_nil component.block_content
-    assert_equal false, component.block_content?
+    assert_nil component.block
+    assert_equal false, component.block?
   end
 
   test "initialize with block" do
     component_class = Class.new(Components::Component)
     component = component_class.new(view_class.new) { "foo" }
-    assert_equal "foo", component.block_content
-    assert_equal true, component.block_content?
+    assert_equal "foo", component.block
+    assert_equal true, component.block?
   end
 
   test "initialize attribute with no value" do
@@ -45,7 +45,7 @@ class ComponentTest < ActiveSupport::TestCase
     end
     component = component_class.new(view_class.new)
     component.foo { "foo" }
-    assert_equal "foo", component.foo.block_content
+    assert_equal "foo", component.foo.block
   end
 
   test "initialize element with attribute with value" do
@@ -72,8 +72,8 @@ class ComponentTest < ActiveSupport::TestCase
       end
       "foo"
     end
-    assert_equal "foo", component.foo.block_content
-    assert_equal "bar", component.foo.bar.block_content
+    assert_equal "foo", component.foo.block
+    assert_equal "bar", component.foo.bar.block
   end
 
   test "initialize element with multiple true" do
@@ -84,8 +84,8 @@ class ComponentTest < ActiveSupport::TestCase
     component.foo { "foo" }
     component.foo { "bar" }
     assert_equal 2, component.foos.length
-    assert_equal "foo", component.foos[0].block_content
-    assert_equal "bar", component.foos[1].block_content
+    assert_equal "foo", component.foos[0].block
+    assert_equal "bar", component.foos[1].block
   end
 
   test "initialize element with multiple true when singular and plural name are the same" do
@@ -96,8 +96,8 @@ class ComponentTest < ActiveSupport::TestCase
     component.foos { "foo" }
     component.foos { "bar" }
     assert_equal 2, component.foos.length
-    assert_equal "foo", component.foos[0].block_content
-    assert_equal "bar", component.foos[1].block_content
+    assert_equal "foo", component.foos[0].block
+    assert_equal "bar", component.foos[1].block
   end
 
   test "get element when not set" do

--- a/test/component_test.rb
+++ b/test/component_test.rb
@@ -4,14 +4,14 @@ class ComponentTest < ActiveSupport::TestCase
   test "initialize with nothing" do
     component_class = Class.new(Components::Component)
     component = component_class.new(view_class.new)
-    assert_nil component.to_s
+    assert_nil component.block_content
     assert_equal false, component.block_content?
   end
 
   test "initialize with block" do
     component_class = Class.new(Components::Component)
     component = component_class.new(view_class.new) { "foo" }
-    assert_equal "foo", component.to_s
+    assert_equal "foo", component.block_content
     assert_equal true, component.block_content?
   end
 
@@ -45,7 +45,7 @@ class ComponentTest < ActiveSupport::TestCase
     end
     component = component_class.new(view_class.new)
     component.foo { "foo" }
-    assert_equal "foo", component.foo.to_s
+    assert_equal "foo", component.foo.block_content
   end
 
   test "initialize element with attribute with value" do
@@ -72,8 +72,8 @@ class ComponentTest < ActiveSupport::TestCase
       end
       "foo"
     end
-    assert_equal "foo", component.foo.to_s
-    assert_equal "bar", component.foo.bar.to_s
+    assert_equal "foo", component.foo.block_content
+    assert_equal "bar", component.foo.bar.block_content
   end
 
   test "initialize element with multiple true" do
@@ -84,8 +84,8 @@ class ComponentTest < ActiveSupport::TestCase
     component.foo { "foo" }
     component.foo { "bar" }
     assert_equal 2, component.foos.length
-    assert_equal "foo", component.foos[0].to_s
-    assert_equal "bar", component.foos[1].to_s
+    assert_equal "foo", component.foos[0].block_content
+    assert_equal "bar", component.foos[1].block_content
   end
 
   test "initialize element with multiple true when singular and plural name are the same" do
@@ -96,8 +96,8 @@ class ComponentTest < ActiveSupport::TestCase
     component.foos { "foo" }
     component.foos { "bar" }
     assert_equal 2, component.foos.length
-    assert_equal "foo", component.foos[0].to_s
-    assert_equal "bar", component.foos[1].to_s
+    assert_equal "foo", component.foos[0].block_content
+    assert_equal "bar", component.foos[1].block_content
   end
 
   test "get element when not set" do

--- a/test/component_test.rb
+++ b/test/component_test.rb
@@ -121,7 +121,6 @@ class ComponentTest < ActiveSupport::TestCase
       attribute :foo
       validates :foo, presence: true
     end
-
     assert_nothing_raised { component_class.new(view_class.new, foo: "bar") }
   end
 
@@ -130,7 +129,6 @@ class ComponentTest < ActiveSupport::TestCase
       attribute :foo
       validates :foo, presence: true
     end
-
     e = assert_raises(ActiveModel::ValidationError) { component_class.new(view_class.new) }
     assert_equal "Validation failed: Foo can't be blank", e.message
   end
@@ -140,7 +138,6 @@ class ComponentTest < ActiveSupport::TestCase
       attribute :foo, default: "bar"
       validates :foo, presence: true
     end
-
     assert_nothing_raised { component_class.new(view_class.new) }
   end
 
@@ -148,11 +145,9 @@ class ComponentTest < ActiveSupport::TestCase
     component_class = Class.new(Components::Component) do
       element :foo do
         attribute :bar
-
         validates :bar, presence: true
       end
     end
-
     assert_nothing_raised do
       component_class.new(view_class.new, {}) do |c|
         c.foo(bar: "lalal") { "something" }
@@ -164,17 +159,14 @@ class ComponentTest < ActiveSupport::TestCase
     component_class = Class.new(Components::Component) do
       element :foo do
         attribute :bar
-
         validates :bar, presence: true
       end
     end
-
     e = assert_raises(ActiveModel::ValidationError) do
       component_class.new(view_class.new, {}) do |c|
         c.foo { "something" }
       end
     end
-
     assert_equal "Validation failed: Bar can't be blank", e.message
   end
 

--- a/test/component_test.rb
+++ b/test/component_test.rb
@@ -117,7 +117,6 @@ class ComponentTest < ActiveSupport::TestCase
   end
 
   class TestValidationComponent < Components::Component
-    include ActiveModel::Validations
     attribute :foo
     validates :foo, presence: true
   end
@@ -133,7 +132,6 @@ class ComponentTest < ActiveSupport::TestCase
   end
 
   class TestValidationWithDefaultComponent < Components::Component
-    include ActiveModel::Validations
     attribute :foo, default: "bar"
     validates :foo, presence: true
   end

--- a/test/component_test.rb
+++ b/test/component_test.rb
@@ -139,7 +139,30 @@ class ComponentTest < ActiveSupport::TestCase
     assert_nothing_raised { component_class.new(view_class.new) }
   end
 
-  test "initialize element and successfull validation" do
+  test "initialize element and successfull element validation" do
+    component_class = Class.new(Components::Component) do
+      element :foo
+      validates :foo, presence: true
+    end
+    assert_nothing_raised do
+      component_class.new(view_class.new, {}) do |c|
+        c.foo { "lalala" }
+      end
+    end
+  end
+
+  test "initialize element and failing element validation" do
+    component_class = Class.new(Components::Component) do
+      element :foo
+      validates :foo, presence: true
+    end
+    e = assert_raises(ActiveModel::ValidationError) do
+      component_class.new(view_class.new, {})
+    end
+    assert_equal "Validation failed: Foo can't be blank", e.message
+  end
+
+  test "initialize element and successfull element attribute validation" do
     component_class = Class.new(Components::Component) do
       element :foo do
         attribute :bar
@@ -153,7 +176,7 @@ class ComponentTest < ActiveSupport::TestCase
     end
   end
 
-  test "initialize element and failing validation" do
+  test "initialize element and failing element attribute validation" do
     component_class = Class.new(Components::Component) do
       element :foo do
         attribute :bar

--- a/test/component_test.rb
+++ b/test/component_test.rb
@@ -136,9 +136,8 @@ class ComponentTest < ActiveSupport::TestCase
       end
     end
 
-    exception = assert_raises { component_class.new(:view) }
-    assert_instance_of ActiveModel::ValidationError, exception
-    assert_equal "Validation failed: Foo can't be blank", exception.message
+    e = assert_raises(ActiveModel::ValidationError) { component_class.new(:view) }
+    assert_equal "Validation failed: Foo can't be blank", e.message
   end
 
   test "initialize with default value and successfull validation" do

--- a/test/component_test.rb
+++ b/test/component_test.rb
@@ -116,28 +116,38 @@ class ComponentTest < ActiveSupport::TestCase
     assert_equal [], component.foos
   end
 
-  class TestValidationComponent < Components::Component
-    attribute :foo
-    validates :foo, presence: true
-  end
-
   test "initialize with given attribute and successfull validation" do
-    assert_nothing_raised { TestValidationComponent.new(:view, foo: "bar") }
+    component_class = Class.new(Components::Component) do
+      attribute :foo
+      validates :foo, presence: true
+    end
+
+    assert_nothing_raised { component_class.new(:view, foo: "bar") }
   end
 
   test "initialize without attribute and failing validation" do
-    exception = assert_raises { TestValidationComponent.new(:view) }
+    component_class = Class.new(Components::Component) do
+      attribute :foo
+      validates :foo, presence: true
+
+      # supplies a name argument for active validations on anonymous classes
+      def self.model_name
+        ActiveModel::Name.new(self, nil, "temp")
+      end
+    end
+
+    exception = assert_raises { component_class.new(:view) }
     assert_instance_of ActiveModel::ValidationError, exception
     assert_equal "Validation failed: Foo can't be blank", exception.message
   end
 
-  class TestValidationWithDefaultComponent < Components::Component
-    attribute :foo, default: "bar"
-    validates :foo, presence: true
-  end
-
   test "initialize with default value and successfull validation" do
-    assert_nothing_raised { TestValidationWithDefaultComponent.new(:view) }
+    component_class = Class.new(Components::Component) do
+      attribute :foo, default: "bar"
+      validates :foo, presence: true
+    end
+
+    assert_nothing_raised { component_class.new(:view) }
   end
 
   private

--- a/test/component_test.rb
+++ b/test/component_test.rb
@@ -26,7 +26,7 @@ class ComponentTest < ActiveSupport::TestCase
       attribute :foo
     end
     component = component_class.new(view_class.new, foo: "foo")
-    assert_equal "foo", component.foo.to_s
+    assert_equal "foo", component.foo
   end
 
   test "initialize attribute with default value" do
@@ -34,7 +34,7 @@ class ComponentTest < ActiveSupport::TestCase
       attribute :foo, default: "foo"
     end
     component = component_class.new(view_class.new)
-    assert_equal "foo", component.foo.to_s
+    assert_equal "foo", component.foo
   end
 
   test "initialize element with block" do
@@ -54,7 +54,7 @@ class ComponentTest < ActiveSupport::TestCase
     end
     component = component_class.new(view_class.new)
     component.foo bar: "baz"
-    assert_equal "baz", component.foo.bar.to_s
+    assert_equal "baz", component.foo.bar
   end
 
   test "initialize element with block with nested element with block" do

--- a/test/component_test.rb
+++ b/test/component_test.rb
@@ -147,7 +147,6 @@ class ComponentTest < ActiveSupport::TestCase
   test "initialize element and successfull validation" do
     component_class = Class.new(Components::Component) do
       element :foo do
-        attribute :label
         attribute :bar
 
         validates :bar, presence: true
@@ -164,7 +163,6 @@ class ComponentTest < ActiveSupport::TestCase
   test "initialize element and failing validation" do
     component_class = Class.new(Components::Component) do
       element :foo do
-        attribute :label
         attribute :bar
 
         validates :bar, presence: true
@@ -173,7 +171,7 @@ class ComponentTest < ActiveSupport::TestCase
 
     e = assert_raises(ActiveModel::ValidationError) do
       component_class.new(view_class.new, {}) do |c|
-        c.foo(label: "lalal") { "label" }
+        c.foo { "something" }
       end
     end
 

--- a/test/dummy/app/components/card/_card.html.erb
+++ b/test/dummy/app/components/card/_card.html.erb
@@ -1,22 +1,22 @@
 <div id="<%= card.id %>" class="card">
   <% if card.header %>
     <div class="card__header">
-      <%= card.header %>
+      <%= card.header.block_content %>
     </div>
   <% end %>
   <% card.sections.each do |section| %>
     <div class="card__section<%= " card__section--#{section.size}" if section.size %>">
-      <% if section.header.present? %>
+      <% if section.header && section.header.block_content? %>
         <div class="card__section__header">
-          <%= section.header %>
+          <%= section.header.block_content %>
         </div>
       <% end %>
-      <%= section %>
+      <%= section.block_content %>
     </div>
   <% end %>
-  <% if card.footer %>
+  <% if card.footer && card.footer.block_content? %>
     <div class="card__footer">
-      <%= card.footer %>
+      <%= card.footer.block_content %>
     </div>
   <% end %>
 </div>

--- a/test/dummy/app/components/card/_card.html.erb
+++ b/test/dummy/app/components/card/_card.html.erb
@@ -1,22 +1,22 @@
 <div id="<%= card.id %>" class="card">
   <% if card.header %>
     <div class="card__header">
-      <%= card.header.block %>
+      <%= card.header %>
     </div>
   <% end %>
   <% card.sections.each do |section| %>
     <div class="card__section<%= " card__section--#{section.size}" if section.size %>">
-      <% if section.header && section.header.block? %>
+      <% if section.header  %>
         <div class="card__section__header">
-          <%= section.header.block %>
+          <%= section.header %>
         </div>
       <% end %>
-      <%= section.block %>
+      <%= section %>
     </div>
   <% end %>
-  <% if card.footer && card.footer.block? %>
+  <% if card.footer %>
     <div class="card__footer">
-      <%= card.footer.block %>
+      <%= card.footer %>
     </div>
   <% end %>
 </div>

--- a/test/dummy/app/components/card/_card.html.erb
+++ b/test/dummy/app/components/card/_card.html.erb
@@ -6,7 +6,7 @@
   <% end %>
   <% card.sections.each do |section| %>
     <div class="card__section<%= " card__section--#{section.size}" if section.size %>">
-      <% if section.header  %>
+      <% if section.header %>
         <div class="card__section__header">
           <%= section.header %>
         </div>

--- a/test/dummy/app/components/card/_card.html.erb
+++ b/test/dummy/app/components/card/_card.html.erb
@@ -1,22 +1,22 @@
 <div id="<%= card.id %>" class="card">
   <% if card.header %>
     <div class="card__header">
-      <%= card.header.block_content %>
+      <%= card.header.block %>
     </div>
   <% end %>
   <% card.sections.each do |section| %>
     <div class="card__section<%= " card__section--#{section.size}" if section.size %>">
-      <% if section.header && section.header.block_content? %>
+      <% if section.header && section.header.block? %>
         <div class="card__section__header">
-          <%= section.header.block_content %>
+          <%= section.header.block %>
         </div>
       <% end %>
-      <%= section.block_content %>
+      <%= section.block %>
     </div>
   <% end %>
-  <% if card.footer && card.footer.block_content? %>
+  <% if card.footer && card.footer.block? %>
     <div class="card__footer">
-      <%= card.footer.block_content %>
+      <%= card.footer.block %>
     </div>
   <% end %>
 </div>

--- a/test/dummy/app/components/objects/media_object/_media_object.html.erb
+++ b/test/dummy/app/components/objects/media_object/_media_object.html.erb
@@ -1,8 +1,8 @@
 <div class="media-object">
   <div class="media-object__media">
-    <%= media_object.media.block %>
+    <%= media_object.media %>
   </div>
   <div class="media-object__body">
-    <%= media_object.body.block %>
+    <%= media_object.body %>
   </div>
 </div>

--- a/test/dummy/app/components/objects/media_object/_media_object.html.erb
+++ b/test/dummy/app/components/objects/media_object/_media_object.html.erb
@@ -1,8 +1,8 @@
 <div class="media-object">
   <div class="media-object__media">
-    <%= media_object.media %>
+    <%= media_object.media.block_content %>
   </div>
   <div class="media-object__body">
-    <%= media_object.body %>
+    <%= media_object.body.block_content %>
   </div>
 </div>

--- a/test/dummy/app/components/objects/media_object/_media_object.html.erb
+++ b/test/dummy/app/components/objects/media_object/_media_object.html.erb
@@ -1,8 +1,8 @@
 <div class="media-object">
   <div class="media-object__media">
-    <%= media_object.media.block_content %>
+    <%= media_object.media.block %>
   </div>
   <div class="media-object__body">
-    <%= media_object.body.block_content %>
+    <%= media_object.body.block %>
   </div>
 </div>


### PR DESCRIPTION
We used the components gem in one of our recent web projects and really enjoyed it :)

To ensure the correct usage of our components we decided to "integrate" rails validations.
Now invalid components will raise validations errors which can be detected by feature specs.

This behaviour is currently enabled for all environments, probably it should be configurable for each environment.

Obviously this is still work in progress - I am just wondering if you would consider merging it?  



