### PR TITLE
Generator now supports namespaced components

### DIFF
--- a/lib/generators/components/component_generator.rb
+++ b/lib/generators/components/component_generator.rb
@@ -5,7 +5,7 @@ module Components
     class_option :skip_css, type: :boolean, default: false
     class_option :skip_js, type: :boolean, default: false
 
-    source_root File.expand_path("../templates", __FILE__)
+    source_root File.expand_path("templates", __dir__)
 
     def create_component_file
       template "component.rb.erb", "app/components/#{name}_component.rb"
@@ -13,23 +13,26 @@ module Components
 
     def create_erb_file
       return if options["skip_erb"]
+
       create_file "app/components/#{name}/_#{filename}.html.erb"
     end
 
     def create_css_file
       return if options["skip_css"]
+
       create_file "app/components/#{name}/#{filename}.css"
     end
 
     def create_js_file
       return if options["skip_js"]
+
       create_file "app/components/#{name}/#{filename}.js"
     end
 
     private
 
     def filename
-      name.split('/').last
+      name.split("/").last
     end
   end
 end

--- a/lib/generators/components/component_generator.rb
+++ b/lib/generators/components/component_generator.rb
@@ -7,10 +7,6 @@ module Components
 
     source_root File.expand_path("../templates", __FILE__)
 
-    def filename
-      name.split('/').last
-    end
-
     def create_component_file
       template "component.rb.erb", "app/components/#{name}_component.rb"
     end
@@ -29,5 +25,12 @@ module Components
       return if options["skip_js"]
       create_file "app/components/#{name}/#{filename}.js"
     end
+
+    private
+
+    def filename
+      name.split('/').last
+    end
+
   end
 end

--- a/lib/generators/components/component_generator.rb
+++ b/lib/generators/components/component_generator.rb
@@ -31,6 +31,5 @@ module Components
     def filename
       name.split('/').last
     end
-
   end
 end

--- a/lib/generators/components/component_generator.rb
+++ b/lib/generators/components/component_generator.rb
@@ -7,23 +7,27 @@ module Components
 
     source_root File.expand_path("../templates", __FILE__)
 
+    def filename
+      name.split('/').last
+    end
+
     def create_component_file
       template "component.rb.erb", "app/components/#{name}_component.rb"
     end
 
     def create_erb_file
       return if options["skip_erb"]
-      create_file "app/components/#{name}/_#{name}.html.erb"
+      create_file "app/components/#{name}/_#{filename}.html.erb"
     end
 
     def create_css_file
       return if options["skip_css"]
-      create_file "app/components/#{name}/#{name}.css"
+      create_file "app/components/#{name}/#{filename}.css"
     end
 
     def create_js_file
       return if options["skip_js"]
-      create_file "app/components/#{name}/#{name}.js"
+      create_file "app/components/#{name}/#{filename}.js"
     end
   end
 end

--- a/test/generators/component_generator_test.rb
+++ b/test/generators/component_generator_test.rb
@@ -14,7 +14,7 @@ class ComponentGeneratorTest < Rails::Generators::TestCase
     assert_file "app/components/foobar/foobar.js"
   end
 
-  test "component generator with sub component" do
+  test "component generator for namespaced component" do
     run_generator %w[baz/foobar]
     assert_file "app/components/baz/foobar_component.rb"
     assert_file "app/components/baz/foobar/_foobar.html.erb"

--- a/test/generators/component_generator_test.rb
+++ b/test/generators/component_generator_test.rb
@@ -13,4 +13,12 @@ class ComponentGeneratorTest < Rails::Generators::TestCase
     assert_file "app/components/foobar/foobar.css"
     assert_file "app/components/foobar/foobar.js"
   end
+
+  test "component generator with sub component" do
+    run_generator %w[baz/foobar]
+    assert_file "app/components/baz/foobar_component.rb"
+    assert_file "app/components/baz/foobar/_foobar.html.erb"
+    assert_file "app/components/baz/foobar/foobar.css"
+    assert_file "app/components/baz/foobar/foobar.js"
+  end
 end


### PR DESCRIPTION
This is a simple change which ensures that `rails g baz/foobar` will properly nest component files under `components/baz/`.