### PR TITLE
Extendable Components

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,29 +577,37 @@ class CardComponent < Components::Component
 end
 ```
 
-### Generating modular classnames
+### Working With Classnames
 
-Hard coding your template classnames is fine, but if you're extending components as elements, it's much nicer to be abl to generate modular classnames.
-Consider a form component which contains a card, like this:
+While hard coding classnames in your templates is fine often we want to assign classnames based on an attribute or set a default classname. Sure we can write this code
+in the view, but it's much cleaner and easier to do so in a component using the `add_class` and `classnames` method.
 
 ```ruby
-class FormComponent < Components::Component
-  element :card, extend 'core/card' do
+class CardComponent < Components::Component
+  attribute :flush
+  add_class 'card'
+
+  element :header do
+    add_class 'card__header'
 
   end
+
+  def classnames
+    add_class 'card--flush' if flush
+    super
+  end
+
 end
 ```
 
-That card's template uses `modular_classname` to generate a classname from its own name and its parents names.
+Then use the `classnames` method in your template to output classnames for that element or component.
 
 ```html
-<div class="<%= card.modular_classname $>">
+<div class="<%= card.classnames %>">
+  <header class="<%= header.classnames %>"><%= header %></header>
   <%= card %>
 </div>
 ```
-
-When used as a standalone card, the classanme would be `card` when used in a form it would be `form__card`.
-
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -585,16 +585,14 @@ in the view, but it's much cleaner and easier to do so in a component using the 
 ```ruby
 class CardComponent < Components::Component
   attribute :flush
-  add_class 'card'
+  classnames.base = 'card'
 
   element :header do
-    add_class 'card__header'
-
+    classnames.base = 'card__header'
   end
 
   def classnames
-    add_class 'card--flush' if flush
-    super
+    super.add 'card--flush' if flush
   end
 
 end

--- a/lib/components.rb
+++ b/lib/components.rb
@@ -1,5 +1,6 @@
 require "components/element"
 require "components/component"
+require "components/classnames"
 require "components/engine"
 
 module Components

--- a/lib/components/classnames.rb
+++ b/lib/components/classnames.rb
@@ -1,0 +1,15 @@
+module Components
+  class Classnames < Array
+    def to_s
+      self.join(' ')
+    end
+
+    # Make it easy to insert a classname as the first class in an array 
+    def base=(name)
+      self.unshift(name)
+    end
+
+    alias_method :base, :first
+    alias_method :add, :push
+  end
+end

--- a/lib/components/component.rb
+++ b/lib/components/component.rb
@@ -5,15 +5,25 @@ module Components
     end
 
     def self.component_name
-      name.chomp("Component").demodulize.underscore
+      class_name.chomp("Component").demodulize.underscore
     end
 
     def self.component_path
-      name.chomp("Component").underscore
+      class_name.chomp("Component").underscore
+    end
+
+    # Allow Components to lookup their original classname
+    # even if created with Class.new(SomeComponent)
+    def self.class_name
+      name || superclass.name
     end
 
     def render
-      @view.render partial: to_partial_path, object: self
+      render_partial to_partial_path
+    end
+
+    def _name
+      super || self.class.component_name
     end
 
     def to_partial_path

--- a/lib/components/element.rb
+++ b/lib/components/element.rb
@@ -7,18 +7,14 @@ module Components
     end
 
     attr_accessor :_name, :block_content
-    attr_reader :parents
+    attr_reader :parents, :classnames
 
     def self.attributes
       @attributes ||= {}
     end
 
     def self.classnames
-      @classnames ||= []
-    end
-
-    def self.add_class(*args)
-      classnames.push(*args)
+      @classnames ||= Components::Classnames.new
     end
 
     def self.attribute(name, default: nil)
@@ -93,8 +89,6 @@ module Components
 
     # Pass on attributes and elements to subclassed elements/components
     def self.inherited(subclass)
-      subclass.add_class classnames
-
       attributes.each do |name, options|
         subclass.attribute(name, options)
       end
@@ -108,7 +102,7 @@ module Components
       @view = view
       @options ||= {}
       @parents = []
-      @classnames = self.class.classnames
+      initialize_classnames
       initialize_attributes(attributes || {})
       initialize_elements
       @block_content = block_given? ? @view.capture(self, &block) : nil
@@ -125,14 +119,6 @@ module Components
 
     def render_partial(file)
       @view.render(partial: file, object: self)
-    end
-
-    def add_class(*args)
-      @classnames.push(*args)
-    end
-
-    def classnames
-      @classnames.join(' ').strip
     end
 
     def to_s
@@ -156,6 +142,11 @@ module Components
           set_instance_variable(name, nil)
         end
       end
+    end
+
+    def initialize_classnames
+      @classnames = self.class.classnames
+      @classnames.add *self.class.superclass.classnames
     end
 
     private

--- a/lib/components/element.rb
+++ b/lib/components/element.rb
@@ -120,11 +120,7 @@ module Components
     end
 
     def parent
-      parents.first
-    end
-
-    def modular_classname(separator: "__")
-      [parents, self].flatten.map(&:_name).join(separator)
+      parents.last
     end
 
     def render_partial(file)
@@ -135,7 +131,7 @@ module Components
       @classnames.push(*args)
     end
 
-    def classname
+    def classnames
       @classnames.join(' ').strip
     end
 

--- a/lib/components/element.rb
+++ b/lib/components/element.rb
@@ -13,6 +13,14 @@ module Components
       @attributes ||= {}
     end
 
+    def self.classnames
+      @classnames ||= []
+    end
+
+    def self.add_class(*args)
+      classnames.push(*args)
+    end
+
     def self.attribute(name, default: nil)
       attributes[name] = { default: default }
 
@@ -85,6 +93,8 @@ module Components
 
     # Pass on attributes and elements to subclassed elements/components
     def self.inherited(subclass)
+      subclass.add_class classnames
+
       attributes.each do |name, options|
         subclass.attribute(name, options)
       end
@@ -98,6 +108,7 @@ module Components
       @view = view
       @options ||= {}
       @parents = []
+      @classnames = self.class.classnames
       initialize_attributes(attributes || {})
       initialize_elements
       @block_content = block_given? ? @view.capture(self, &block) : nil
@@ -118,6 +129,14 @@ module Components
 
     def render_partial(file)
       @view.render(partial: file, object: self)
+    end
+
+    def add_class(*args)
+      @classnames.push(*args)
+    end
+
+    def classname
+      @classnames.join(' ').strip
     end
 
     def to_s

--- a/test/component_test.rb
+++ b/test/component_test.rb
@@ -353,6 +353,23 @@ class ComponentTest < ActiveSupport::TestCase
     assert_equal "form__card__foo__bar", component_2.card.foo.bar.modular_classname
   end
 
+  test "elements can to manage classnames" do
+    component_class = Class.new(Components::Component) do
+      attribute :baz
+      add_class :foo, :bar
+
+      def classname
+        add_class 'baz' if baz
+        super
+      end
+    end
+    component = component_class.new(view_class.new)
+    assert_equal "foo bar", component.classname
+
+    component_2 = component_class.new(view_class.new, baz: true)
+    assert_equal "foo bar baz", component_2.classname
+  end
+
   private
 
   def view_class

--- a/test/component_test.rb
+++ b/test/component_test.rb
@@ -323,51 +323,21 @@ class ComponentTest < ActiveSupport::TestCase
     assert_equal "hi, hello, (yo, howdy)", component.items.join(", ")
   end
 
-  test "classnames can be derived from element structure" do
-    class CardComponent < Components::Component
-      element :foo do
-        element :bar
-      end
-    end
-
-    component = CardComponent.new(view_class.new)
-    component.foo { "" }
-    component.foo.bar { "" }
-
-    assert_equal "card", component.modular_classname
-    assert_equal "card__foo", component.foo.modular_classname
-    assert_equal "card--foo--bar", component.foo.bar.modular_classname(separator: "--")
-
-    class FormComponent < Components::Component
-      element :card, extends: CardComponent
-    end
-
-    component_2 = FormComponent.new(view_class.new)
-    component_2.card { "" }
-    component_2.card.foo { "" }
-    component_2.card.foo.bar { "" }
-
-    assert_equal "form", component_2.modular_classname
-    assert_equal "form__card", component_2.card.modular_classname
-    assert_equal "form__card__foo", component_2.card.foo.modular_classname
-    assert_equal "form__card__foo__bar", component_2.card.foo.bar.modular_classname
-  end
-
   test "elements can to manage classnames" do
     component_class = Class.new(Components::Component) do
       attribute :baz
       add_class :foo, :bar
 
-      def classname
+      def classnames
         add_class 'baz' if baz
         super
       end
     end
     component = component_class.new(view_class.new)
-    assert_equal "foo bar", component.classname
+    assert_equal "foo bar", component.classnames
 
     component_2 = component_class.new(view_class.new, baz: true)
-    assert_equal "foo bar baz", component_2.classname
+    assert_equal "foo bar baz", component_2.classnames
   end
 
   private

--- a/test/component_test.rb
+++ b/test/component_test.rb
@@ -326,18 +326,39 @@ class ComponentTest < ActiveSupport::TestCase
   test "elements can to manage classnames" do
     component_class = Class.new(Components::Component) do
       attribute :baz
-      add_class :foo, :bar
+      classnames.add :foo, :bar
 
       def classnames
-        add_class 'baz' if baz
+        super.add :baz if baz
         super
       end
     end
     component = component_class.new(view_class.new)
-    assert_equal "foo bar", component.classnames
+    assert_equal "foo bar", component.classnames.to_s
 
     component_2 = component_class.new(view_class.new, baz: true)
-    assert_equal "foo bar baz", component_2.classnames
+    assert_equal "foo bar baz", component_2.classnames.to_s
+  end
+
+  test "components inherit classnames when extending other components" do
+    base_component_class = Class.new(Components::Component) do
+      classnames.add 'component'
+
+      element :foo do
+        classnames.add 'foo'
+      end
+    end
+
+    component_class = Class.new(base_component_class) do
+      element :foo do
+        classnames.add 'foo--alt'
+      end
+    end
+
+    component = component_class.new(view_class.new)
+    component.foo { "test" }
+    assert_equal "component", component.classnames.to_s
+    assert_equal "foo--alt foo", component.foo.classnames.to_s
   end
 
   private


### PR DESCRIPTION
This allows Components to extend other components, replicating attributes and child elements. Components which extend another component can redefined child elements or attributes, behaving much the same way as you'd expect extending a class to behave.

Sometimes it would be really useful to render a component beneath another component as an element. For example, a standalone "Card" might behave slightly differently than a "Form > Card". By allowing a Form's card element to extend the `CardComponent`, users can set new defaults, add methods, or do whatever to customize the Form > Card without having to redefine the whole component as an element.

I'm struggling with how to allow components and elements to reference their own names and manage their output. In this I allow elements to override their `to_s` output by defining a render method.  The more interesting and useful This is related to #32.

There's a lot going on here and I'm happy to break it up into smaller pieces if you like. I also totally understand if this isn't a direction you want to head. For me, this is the first thing I wanted to do as soon as I got components working.